### PR TITLE
Chronic::Numerizer Test Class Change Request

### DIFF
--- a/lib/numerizer/numerizer.rb
+++ b/lib/numerizer/numerizer.rb
@@ -29,7 +29,8 @@ class Numerizer
 
   TEN_PREFIXES = [ ['twenty', 20],
                     ['thirty', 30],
-                    ['fourty', 40],
+                    ['forty', 40],
+                    ['fourty', 40], # another common mis-spelling; see http://lmgtfy.com/?q=forty+or+fourty
                     ['fifty', 50],
                     ['sixty', 60],
                     ['seventy', 70],

--- a/test/test_Numerizer.rb
+++ b/test/test_Numerizer.rb
@@ -23,6 +23,8 @@ class ParseNumbersTest < Test::Unit::TestCase
       'thirty-seven' => 37,
       'thirty seven' => 37,
       'fifty nine' => 59,
+      'forty two' => 42,
+      'fourty two' => 42,
       # 'a hundred' => 100,
       'one hundred' => 100,
       'one hundred and fifty' => 150,


### PR DESCRIPTION
Hi there,

I'm working with chronic and noticed that some of the test cases for the Numerizer class aren't evaluated. The hash of test data's keys are numeric & sometimes repeated, which means that the following (when foreach'd) will have one test case...

<pre>
strings = {
  100 => 'a hundred', # this is key's value is overridden / never tested :-(
  100 => 'one hundred'  }
</pre>


where as if I simply switch the order of the key-value pairs, there will be two...

<pre>
strings = {
'a hundred' => 100,
'one hundred' => 100 }
</pre>


Best regards,
  Lee Reilly
