### PR TITLE
Error is Chronic::Numerizer - 'Fourty' should be 'Forty'

### DIFF
--- a/lib/numerizer/numerizer.rb
+++ b/lib/numerizer/numerizer.rb
@@ -29,7 +29,8 @@ class Numerizer
 
   TEN_PREFIXES = [ ['twenty', 20],
                     ['thirty', 30],
-                    ['fourty', 40],
+                    ['forty', 40],
+                    ['fourty', 40], # another common mis-spelling; see http://lmgtfy.com/?q=forty+or+fourty
                     ['fifty', 50],
                     ['sixty', 60],
                     ['seventy', 70],

--- a/test/test_Numerizer.rb
+++ b/test/test_Numerizer.rb
@@ -23,6 +23,8 @@ class ParseNumbersTest < Test::Unit::TestCase
       'thirty-seven' => 37,
       'thirty seven' => 37,
       'fifty nine' => 59,
+      'forty two' => 42,
+      'fourty two' => 42,
       # 'a hundred' => 100,
       'one hundred' => 100,
       'one hundred and fifty' => 150,


### PR DESCRIPTION
Hi again,

I have another pull request for Chronic's Numerizer class. I believe the number 40 is misspelled in the Numerizer class:

<pre>
TEN_PREFIXES = [
   ...
   ['thirty', 30],
   ['fourty', 40], # This should be 'forty'
   ['fifty', 50],
...
]
</pre>


I added support for both as you did originally for 'nineteen' and 'ninteen'. 

Best regards,
  Lee Reilly
