### PR TITLE
ruby 1.8 tests compatibility

### DIFF
--- a/test/test_parsing.rb
+++ b/test/test_parsing.rb
@@ -234,14 +234,14 @@ class TestParsing < Test::Unit::TestCase
 
     # old dates
 
-    time = parse_now("may 40")
-    assert_equal Time.local(2040, 5, 16, 12, 0, 0), time
+    time = parse_now("may 32")
+    assert_equal Time.local(2032, 5, 16, 12, 0, 0), time
 
-    time = parse_now("may 27 40")
-    assert_equal Time.local(2040, 5, 27, 12, 0, 0), time
+    time = parse_now("may 27 32")
+    assert_equal Time.local(2032, 5, 27, 12, 0, 0), time
 
-    time = parse_now("1800-08-20")
-    assert_equal Time.local(1800, 8, 20, 12, 0, 0), time
+    time = parse_now("1902-08-20")
+    assert_equal Time.local(1902, 8, 20, 12, 0, 0), time
   end
 
   def test_parse_two_digit_years
@@ -251,8 +251,8 @@ class TestParsing < Test::Unit::TestCase
     time = parse_now("may 1st 01")
     assert_equal Time.local(2001, 5, 1, 12), time
 
-    time = parse_now("may 79", :ambiguous_year_future_bias => 10)
-    assert_equal Time.local(2079, 5, 16, 12), time
+    time = parse_now("may 33", :ambiguous_year_future_bias => 10)
+    assert_equal Time.local(2033, 5, 16, 12), time
   end
 
   def test_parse_guess_r


### PR DESCRIPTION
since ruby's 1.8 Time class is a wrapper around `time_t`  the valid range of a timestamp is from 1901 to 2038
nash@nash:~$ ruby -v
ruby 1.8.7 (2011-02-18 patchlevel 334) [i686-linux]

``` ruby
irb(main):002:0> Time.local(2077,1,1)
ArgumentError: time out of range
        from (irb):2:in `local'
        from (irb):2
```

I think you can get this error only on 32bit system.
