### PR TITLE
Replace a comma with a space instead of removing the comma completely

### DIFF
--- a/lib/chronic/chronic.rb
+++ b/lib/chronic/chronic.rb
@@ -111,7 +111,8 @@ module Chronic
     # @return [String] A new string ready for Chronic to parse
     def pre_normalize(text)
       text = text.to_s.downcase
-      text.gsub!(/['"\.,]/, '')
+      text.gsub!(/['"\.]/, '')
+      text.gsub!(/,/,' ')
       text.gsub!(/\bsecond (of|day|month|hour|minute|second)\b/, '2nd \1')
       text = numericize_numbers(text)
       text.gsub!(/ \-(\d{4})\b/, ' tzminus\1')

--- a/test/test_parsing.rb
+++ b/test/test_parsing.rb
@@ -112,6 +112,9 @@ class TestParsing < Test::Unit::TestCase
   def test_handle_rmn_sd_sy
     time = parse_now("November 18, 2010")
     assert_equal Time.local(2010, 11, 18, 12), time
+    
+    time = parse_now("Jan 1,2010")
+    assert_equal Time.local(2010, 1, 1, 12), time
 
     time = parse_now("February 14, 2004")
     assert_equal Time.local(2004, 2, 14, 12), time


### PR DESCRIPTION
This allows for things like   Jan 1,2010 to be interpreted correctly as Jan 1 2010, instead of as Jan 12010  -- All other tests still pass.
