### PR TITLE
fixed parsing bug with "noon" and :ambiguous_time_range => :none

### DIFF
--- a/lib/chronic/chronic.rb
+++ b/lib/chronic/chronic.rb
@@ -118,7 +118,7 @@ module Chronic
       text.gsub!(/\btoday\b/, 'this day')
       text.gsub!(/\btomm?orr?ow\b/, 'next day')
       text.gsub!(/\byesterday\b/, 'last day')
-      text.gsub!(/\bnoon\b/, '12:00')
+      text.gsub!(/\bnoon\b/, '12:00pm')
       text.gsub!(/\bmidnight\b/, '24:00')
       text.gsub!(/\bnow\b/, 'this second')
       text.gsub!(/\b(?:ago|before(?: now)?)\b/, 'past')

--- a/test/test_parsing.rb
+++ b/test/test_parsing.rb
@@ -868,6 +868,11 @@ class TestParsing < Test::Unit::TestCase
     t2 = Chronic.parse("now")
     assert_not_equal t1, t2
   end
+  
+  def test_noon
+    t1 = Chronic.parse('2011-01-01 at noon', :ambiguous_time_range => :none)
+    assert_equal Time.local(2011, 1, 1, 12, 0), t1
+  end
 
   private
   def parse_now(string, options={})


### PR DESCRIPTION
Fixed bug where 'noon' was parsed as 00:00 rather than 12:00 with :ambiguous_time_range => :none

Apologies if I'm sending this pull request to the wrong branch. Should I have sent it to develop instead of master? http://lee.jarvis.co/chronic/#GitHub doesn't say.
