### PR TITLE
Chronic.parse("thur") no longer returns nil

### DIFF
--- a/lib/chronic/repeater.rb
+++ b/lib/chronic/repeater.rb
@@ -58,7 +58,7 @@ module Chronic
         /^m[ou]n(day)?$/ => :monday,
         /^t(ue|eu|oo|u|)s?(day)?$/ => :tuesday,
         /^we(d|dnes|nds|nns)(day)?$/ => :wednesday,
-        /^th(u(?:rs)?|ers)(day)?$/ => :thursday,
+        /^th(u|ur|urs|ers)(day)?$/ => :thursday,
         /^fr[iy](day)?$/ => :friday,
         /^sat(t?[ue]rday)?$/ => :saturday,
         /^su[nm](day)?$/ => :sunday

--- a/test/test_parsing.rb
+++ b/test/test_parsing.rb
@@ -539,6 +539,34 @@ class TestParsing < Test::Unit::TestCase
     time = parse_now("last wed")
     assert_equal Time.local(2006, 8, 9, 12), time
 
+    monday = Time.local(2006, 8, 21, 12)
+    assert_equal monday, parse_now("mon")
+    assert_equal monday, parse_now("mun")
+
+    tuesday = Time.local(2006, 8, 22, 12)
+    assert_equal tuesday, parse_now("tue")
+    assert_equal tuesday, parse_now("tus")
+
+    wednesday = Time.local(2006, 8, 23, 12)
+    assert_equal wednesday, parse_now("wed")
+    assert_equal wednesday, parse_now("wenns")
+
+    thursday = Time.local(2006, 8, 17, 12)
+    assert_equal thursday, parse_now("thu")
+    assert_equal thursday, parse_now("thur")
+
+    friday = Time.local(2006, 8, 18, 12)
+    assert_equal friday, parse_now("fri")
+    assert_equal friday, parse_now("fry")
+
+    saturday = Time.local(2006, 8, 19, 12)
+    assert_equal saturday, parse_now("sat")
+    assert_equal saturday, parse_now("satterday")
+
+    sunday = Time.local(2006, 8, 20, 12)
+    assert_equal sunday, parse_now("sun")
+    assert_equal sunday, parse_now("sum")
+
     # day portion
 
     time = parse_now("this morning")


### PR DESCRIPTION
My users keep getting owned by "thur" not being parsed as Thursday.

This patch fixes that. All the tests still pass on my machine for utc, bst, mst, and mdt.

Also, after looking at the code, I'm also enamored and impressed with the general looseness of the RepeaterDayName. In addition to testing my new functionality, I've added a few other tests to ensure some of the livelier spellings remain valid for all time.

Regards,
-Harold
