### PR TITLE
Add tests for the Day Portion Repeater…with DST fix

### DIFF
--- a/lib/chronic/repeaters/repeater_day_portion.rb
+++ b/lib/chronic/repeaters/repeater_day_portion.rb
@@ -25,8 +25,6 @@ module Chronic
     def next(pointer)
       super
 
-      full_day = 60 * 60 * 24
-
       if !@current_span
         now_seconds = @now - Chronic.construct(@now.year, @now.month, @now.day)
         if now_seconds < @range.begin
@@ -34,32 +32,38 @@ module Chronic
           when :future
             range_start = Chronic.construct(@now.year, @now.month, @now.day) + @range.begin
           when :past
-            range_start = Chronic.construct(@now.year, @now.month, @now.day) - full_day + @range.begin
+            range_start = Chronic.construct(@now.year, @now.month, @now.day - 1) + @range.begin
           end
         elsif now_seconds > @range.end
           case pointer
           when :future
-            range_start = Chronic.construct(@now.year, @now.month, @now.day) + full_day + @range.begin
+            range_start = Chronic.construct(@now.year, @now.month, @now.day + 1) + @range.begin
           when :past
             range_start = Chronic.construct(@now.year, @now.month, @now.day) + @range.begin
           end
         else
           case pointer
           when :future
-            range_start = Chronic.construct(@now.year, @now.month, @now.day) + full_day + @range.begin
+            range_start = Chronic.construct(@now.year, @now.month, @now.day + 1) + @range.begin
           when :past
-            range_start = Chronic.construct(@now.year, @now.month, @now.day) - full_day + @range.begin
+            range_start = Chronic.construct(@now.year, @now.month, @now.day - 1) + @range.begin
           end
         end
-
-        @current_span = Span.new(range_start, range_start + (@range.end - @range.begin))
+        offset = (@range.end - @range.begin)
+        range_end = construct_date_from_reference_and_offset(range_start, offset)
+        @current_span = Span.new(range_start, range_end)
       else
+        days_to_shift_window =
         case pointer
         when :future
-          @current_span += full_day
+          1
         when :past
-          @current_span -= full_day
+          -1
         end
+
+        new_begin = Chronic.construct(@current_span.begin.year, @current_span.begin.month, @current_span.begin.day + days_to_shift_window, @current_span.begin.hour, @current_span.begin.min, @current_span.begin.sec)
+        new_end = Chronic.construct(@current_span.end.year, @current_span.end.month, @current_span.end.day + days_to_shift_window, @current_span.end.hour, @current_span.end.min, @current_span.end.sec)
+        @current_span = Span.new(new_begin, new_end)
       end
     end
 
@@ -67,7 +71,8 @@ module Chronic
       super
 
       range_start = Chronic.construct(@now.year, @now.month, @now.day) + @range.begin
-      @current_span = Span.new(range_start, range_start + (@range.end - @range.begin))
+      range_end = construct_date_from_reference_and_offset(range_start)
+      @current_span = Span.new(range_start, range_end)
     end
 
     def offset(span, amount, pointer)
@@ -89,6 +94,15 @@ module Chronic
 
     def to_s
       super << '-dayportion-' << @type.to_s
+    end
+
+    private
+    def construct_date_from_reference_and_offset(reference, offset = nil)
+      elapsed_seconds_for_range = offset || (@range.end - @range.begin)
+      second_hand = ((elapsed_seconds_for_range - (12 * 60))) % 60
+      minute_hand = (elapsed_seconds_for_range - second_hand) / (60) % 60
+      hour_hand = (elapsed_seconds_for_range - minute_hand - second_hand) / (60 * 60) + reference.hour % 24
+      Chronic.construct(reference.year, reference.month, reference.day, hour_hand, minute_hand, second_hand)
     end
   end
 end

--- a/test/test_repeater_day_portion.rb
+++ b/test/test_repeater_day_portion.rb
@@ -1,0 +1,254 @@
+require 'helper'
+
+class TestRepeaterDayPortion < TestCase
+
+  def setup
+    @now = Time.local(2006, 8, 16, 14, 0, 0, 0)
+  end
+  
+  def test_am_future
+    day_portion = Chronic::RepeaterDayPortion.new(:am)
+    day_portion.start = @now
+    
+    next_time = day_portion.next(:future)
+    assert_equal Time.local(2006, 8, 17, 00), next_time.begin
+    assert_equal Time.local(2006, 8, 17, 11, 59, 59), next_time.end
+
+    next_next_time = day_portion.next(:future)
+    assert_equal Time.local(2006, 8, 18, 00), next_next_time.begin
+    assert_equal Time.local(2006, 8, 18, 11, 59, 59), next_next_time.end
+  end
+
+  def test_am_past
+    day_portion = Chronic::RepeaterDayPortion.new(:am)
+    day_portion.start = @now
+    
+    next_time = day_portion.next(:past)
+    assert_equal Time.local(2006, 8, 16, 00), next_time.begin
+    assert_equal Time.local(2006, 8, 16, 11, 59, 59), next_time.end
+
+    next_next_time = day_portion.next(:past)
+    assert_equal Time.local(2006, 8, 15, 00), next_next_time.begin
+    assert_equal Time.local(2006, 8, 15, 11, 59, 59), next_next_time.end
+  end
+  
+  def test_am_future_with_daylight_savings_time_boundary
+    @now = Time.local(2012,11,3,0,0,0)
+    day_portion = Chronic::RepeaterDayPortion.new(:am)
+    day_portion.start = @now
+    
+    next_time = day_portion.next(:future)
+    assert_equal Time.local(2012, 11, 4, 00), next_time.begin
+    assert_equal Time.local(2012, 11, 4, 11, 59, 59), next_time.end
+
+    next_next_time = day_portion.next(:future)
+
+    assert_equal Time.local(2012, 11, 5, 00), next_next_time.begin
+    assert_equal Time.local(2012, 11, 5, 11, 59, 59), next_next_time.end
+  end
+
+  def test_pm_future
+    day_portion = Chronic::RepeaterDayPortion.new(:pm)
+    day_portion.start = @now
+    
+    next_time = day_portion.next(:future)
+    assert_equal Time.local(2006, 8, 17, 12), next_time.begin
+    assert_equal Time.local(2006, 8, 17, 23, 59, 59), next_time.end
+
+    next_next_time = day_portion.next(:future)
+    assert_equal Time.local(2006, 8, 18, 12), next_next_time.begin
+    assert_equal Time.local(2006, 8, 18, 23, 59, 59), next_next_time.end
+  end
+
+  def test_pm_past
+    day_portion = Chronic::RepeaterDayPortion.new(:pm)
+    day_portion.start = @now
+    
+    next_time = day_portion.next(:past)
+    assert_equal Time.local(2006, 8, 15, 12), next_time.begin
+    assert_equal Time.local(2006, 8, 15, 23, 59, 59), next_time.end
+
+    next_next_time = day_portion.next(:past)
+    assert_equal Time.local(2006, 8, 14, 12), next_next_time.begin
+    assert_equal Time.local(2006, 8, 14, 23, 59, 59), next_next_time.end
+  end
+  
+  def test_pm_future_with_daylight_savings_time_boundary
+    @now = Time.local(2012,11,3,0,0,0)
+    day_portion = Chronic::RepeaterDayPortion.new(:pm)
+    day_portion.start = @now
+    
+    next_time = day_portion.next(:future)
+    assert_equal Time.local(2012, 11, 3, 12), next_time.begin
+    assert_equal Time.local(2012, 11, 3, 23, 59, 59), next_time.end
+
+    next_next_time = day_portion.next(:future)
+
+    assert_equal Time.local(2012, 11, 4, 12), next_next_time.begin
+    assert_equal Time.local(2012, 11, 4, 23, 59, 59), next_next_time.end
+  end
+
+  def test_morning_future
+    day_portion = Chronic::RepeaterDayPortion.new(:morning)
+    day_portion.start = @now
+    
+    next_time = day_portion.next(:future)
+    assert_equal Time.local(2006, 8, 17, 6), next_time.begin
+    assert_equal Time.local(2006, 8, 17, 12), next_time.end
+
+    next_next_time = day_portion.next(:future)
+    assert_equal Time.local(2006, 8, 18, 6), next_next_time.begin
+    assert_equal Time.local(2006, 8, 18, 12), next_next_time.end
+  end
+
+  def test_morning_past
+    day_portion = Chronic::RepeaterDayPortion.new(:morning)
+    day_portion.start = @now
+    
+    next_time = day_portion.next(:past)
+    assert_equal Time.local(2006, 8, 16, 6), next_time.begin
+    assert_equal Time.local(2006, 8, 16, 12), next_time.end
+
+    next_next_time = day_portion.next(:past)
+    assert_equal Time.local(2006, 8, 15, 6), next_next_time.begin
+    assert_equal Time.local(2006, 8, 15, 12), next_next_time.end
+  end
+  
+  def test_morning_future_with_daylight_savings_time_boundary
+    @now = Time.local(2012,11,3,0,0,0)
+    day_portion = Chronic::RepeaterDayPortion.new(:morning)
+    day_portion.start = @now
+    
+    next_time = day_portion.next(:future)
+    assert_equal Time.local(2012, 11, 3, 6), next_time.begin
+    assert_equal Time.local(2012, 11, 3, 12), next_time.end
+
+    next_next_time = day_portion.next(:future)
+
+    assert_equal Time.local(2012, 11, 4, 6), next_next_time.begin
+    assert_equal Time.local(2012, 11, 4, 12), next_next_time.end
+  end
+
+  def test_afternoon_future
+    day_portion = Chronic::RepeaterDayPortion.new(:afternoon)
+    day_portion.start = @now
+    
+    next_time = day_portion.next(:future)
+    assert_equal Time.local(2006, 8, 17, 13), next_time.begin
+    assert_equal Time.local(2006, 8, 17, 17), next_time.end
+
+    next_next_time = day_portion.next(:future)
+    assert_equal Time.local(2006, 8, 18, 13), next_next_time.begin
+    assert_equal Time.local(2006, 8, 18, 17), next_next_time.end
+  end
+
+  def test_afternoon_past
+    day_portion = Chronic::RepeaterDayPortion.new(:afternoon)
+    day_portion.start = @now
+    
+    next_time = day_portion.next(:past)
+    assert_equal Time.local(2006, 8, 15, 13), next_time.begin
+    assert_equal Time.local(2006, 8, 15, 17), next_time.end
+
+    next_next_time = day_portion.next(:past)
+    assert_equal Time.local(2006, 8, 14, 13), next_next_time.begin
+    assert_equal Time.local(2006, 8, 14, 17), next_next_time.end
+  end
+  
+  def test_afternoon_future_with_daylight_savings_time_boundary
+    @now = Time.local(2012,11,3,0,0,0)
+    day_portion = Chronic::RepeaterDayPortion.new(:afternoon)
+    day_portion.start = @now
+    
+    next_time = day_portion.next(:future)
+    assert_equal Time.local(2012, 11, 3, 13), next_time.begin
+    assert_equal Time.local(2012, 11, 3, 17), next_time.end
+
+    next_next_time = day_portion.next(:future)
+
+    assert_equal Time.local(2012, 11, 4, 13), next_next_time.begin
+    assert_equal Time.local(2012, 11, 4, 17), next_next_time.end
+  end
+
+  def test_evening_future
+    day_portion = Chronic::RepeaterDayPortion.new(:evening)
+    day_portion.start = @now
+    
+    next_time = day_portion.next(:future)
+    assert_equal Time.local(2006, 8, 16, 17), next_time.begin
+    assert_equal Time.local(2006, 8, 16, 20), next_time.end
+
+    next_next_time = day_portion.next(:future)
+    assert_equal Time.local(2006, 8, 17, 17), next_next_time.begin
+    assert_equal Time.local(2006, 8, 17, 20), next_next_time.end
+  end
+
+  def test_evening_past
+    day_portion = Chronic::RepeaterDayPortion.new(:evening)
+    day_portion.start = @now
+    
+    next_time = day_portion.next(:past)
+    assert_equal Time.local(2006, 8, 15, 17), next_time.begin
+    assert_equal Time.local(2006, 8, 15, 20), next_time.end
+
+    next_next_time = day_portion.next(:past)
+    assert_equal Time.local(2006, 8, 14, 17), next_next_time.begin
+    assert_equal Time.local(2006, 8, 14, 20), next_next_time.end
+  end
+  
+  def test_evening_future_with_daylight_savings_time_boundary
+    @now = Time.local(2012,11,3,0,0,0)
+    day_portion = Chronic::RepeaterDayPortion.new(:evening)
+    day_portion.start = @now
+    
+    next_time = day_portion.next(:future)
+    assert_equal Time.local(2012, 11, 3, 17), next_time.begin
+    assert_equal Time.local(2012, 11, 3, 20), next_time.end
+
+    next_next_time = day_portion.next(:future)
+
+    assert_equal Time.local(2012, 11, 4, 17), next_next_time.begin
+    assert_equal Time.local(2012, 11, 4, 20), next_next_time.end
+  end
+
+  def test_night_future
+    day_portion = Chronic::RepeaterDayPortion.new(:night)
+    day_portion.start = @now
+    
+    next_time = day_portion.next(:future)
+    assert_equal Time.local(2006, 8, 16, 20), next_time.begin
+    assert_equal Time.local(2006, 8, 17, 0), next_time.end
+
+    next_next_time = day_portion.next(:future)
+    assert_equal Time.local(2006, 8, 17, 20), next_next_time.begin
+    assert_equal Time.local(2006, 8, 18, 0), next_next_time.end
+  end
+
+  def test_night_past
+    day_portion = Chronic::RepeaterDayPortion.new(:night)
+    day_portion.start = @now
+    
+    next_time = day_portion.next(:past)
+    assert_equal Time.local(2006, 8, 15, 20), next_time.begin
+    assert_equal Time.local(2006, 8, 16, 0), next_time.end
+
+    next_next_time = day_portion.next(:past)
+    assert_equal Time.local(2006, 8, 14, 20), next_next_time.begin
+    assert_equal Time.local(2006, 8, 15, 0), next_next_time.end
+  end
+  
+  def test_night_future_with_daylight_savings_time_boundary
+    @now = Time.local(2012,11,3,0,0,0)
+    day_portion = Chronic::RepeaterDayPortion.new(:night)
+    day_portion.start = @now
+    
+    next_time = day_portion.next(:future)
+    assert_equal Time.local(2012, 11, 3, 20), next_time.begin
+    assert_equal Time.local(2012, 11, 4, 0), next_time.end
+
+    next_next_time = day_portion.next(:future)
+
+    assert_equal Time.local(2012, 11, 4, 20), next_next_time.begin
+    assert_equal Time.local(2012, 11, 5, 0), next_next_time.end
+  end
+end


### PR DESCRIPTION
In addition to adding tests for the RepeaterDayPortion, the class now
properly handles construction of date ranges in which the end time
occurs on a day in which the time changes.

Addresses issue #87

The code may not be pretty, but it provides insights into how we can address the chronic Chronic issues with time changes.
