### PR TITLE
Make Chronic.now thread-local (fixes #121, #123)

### DIFF
--- a/lib/chronic.rb
+++ b/lib/chronic.rb
@@ -58,7 +58,14 @@ module Chronic
     #   Chronic.parse('tomorrow', :now => now) #=> 2025-12-25 12:00:00 +0000
     #
     # Returns a Time object.
-    attr_accessor :now
+    #
+    # To ensure thread safety, this value is thread-local.
+    def now
+      Thread.current[:__Chronic_now]
+    end
+    def now=(time)
+      Thread.current[:__Chronic_now] = time
+    end
   end
 
   self.debug = false


### PR DESCRIPTION
Hi! I felt pretty silly the other day after reporting bugs from a 2-year old version of Chronic, so I decided to contribute a patch as a penance.

I saw issues #121 and #123 in the tracker, and they looked easy enough to fix. I did something different from the suggested fix (passing "now" as an argument everywhere it is needed)... have a look and see what you think.
