### PR TITLE
Added next/last week to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ Simple
 * yesterday
 * today
 * tomorrow
+* last week
+* next week
 * this tuesday
 * next month
 * last winter


### PR DESCRIPTION
I added "next week" and "last week" to the documentation list of simple supported phrases.
