### PR TITLE
allow m/d/y that include a time with a timezone

### DIFF
--- a/lib/chronic/parser.rb
+++ b/lib/chronic/parser.rb
@@ -197,6 +197,7 @@ module Chronic
 
       endians = [
         Handler.new([:scalar_month, :separator_slash_or_dash, :scalar_day, :separator_slash_or_dash, :scalar_year, :separator_at?, 'time?'], :handle_sm_sd_sy),
+        Handler.new([:scalar_month, :separator_slash_or_dash, :scalar_day, :separator_slash_or_dash, :scalar_year, :repeater_time, :time_zone], :handle_sm_sd_sy),
         Handler.new([:scalar_month, :separator_slash_or_dash, :scalar_day, :separator_at?, 'time?'], :handle_sm_sd),
         Handler.new([:scalar_day, :separator_slash_or_dash, :scalar_month, :separator_at?, 'time?'], :handle_sd_sm),
         Handler.new([:scalar_day, :separator_slash_or_dash, :scalar_month, :separator_slash_or_dash, :scalar_year, :separator_at?, 'time?'], :handle_sd_sm_sy)

--- a/test/test_chronic.rb
+++ b/test/test_chronic.rb
@@ -59,6 +59,7 @@ class TestChronic < TestCase
     # middle, little
     endians = [
       Chronic::Handler.new([:scalar_month, :separator_slash_or_dash, :scalar_day, :separator_slash_or_dash, :scalar_year, :separator_at?, 'time?'], :handle_sm_sd_sy),
+      Chronic::Handler.new([:scalar_month, :separator_slash_or_dash, :scalar_day, :separator_slash_or_dash, :scalar_year, :repeater_time, :time_zone], :handle_sm_sd_sy),
       Chronic::Handler.new([:scalar_month, :separator_slash_or_dash, :scalar_day, :separator_at?, 'time?'], :handle_sm_sd),
       Chronic::Handler.new([:scalar_day, :separator_slash_or_dash, :scalar_month, :separator_at?, 'time?'], :handle_sd_sm),
       Chronic::Handler.new([:scalar_day, :separator_slash_or_dash, :scalar_month, :separator_slash_or_dash, :scalar_year, :separator_at?, 'time?'], :handle_sd_sm_sy)

--- a/test/test_parsing.rb
+++ b/test/test_parsing.rb
@@ -276,6 +276,9 @@ class TestParsing < TestCase
     time = parse_now("9/19/2011 6:05:57 PM")
     assert_equal Time.local(2011, 9, 19, 18, 05, 57), time
 
+    time = parse_now("9/19/2011 6:05:57 UTC")
+    assert_equal Time.local(2011, 9, 19, 6, 05, 57), time
+
     # month day overflows
     time = parse_now("30/2/2000")
     assert_nil time


### PR DESCRIPTION
Not sure if this is the best way to do this or if there is a reason not to do it, but I needed to parse '12/05/2012 06:00 CST' and Chronic was returning nil for this. This is also related to #134.
