### PR TITLE
Fix failing year/month parsing test

### DIFF
--- a/test/test_parsing.rb
+++ b/test/test_parsing.rb
@@ -367,8 +367,8 @@ class TestParsing < TestCase
     time = parse_now("2012-06")
     assert_equal Time.local(2012, 06, 16), time
 
-    time = parse_now("2013/11")
-    assert_equal Time.local(2013, 11, 16), time
+    time = parse_now("2013/12")
+    assert_equal Time.local(2013, 12, 16, 12, 0), time
   end
 
   def test_handle_r


### PR DESCRIPTION
This test was failing because daylight savings time (DST) is in effect at the start of November 2013 and not at the end of that month.  I opted to move test the a month that is (hopefully) immune from season-related timezone offset changes: December.
