### PR TITLE
Accept a string to parse for the :now option param

### DIFF
--- a/lib/chronic/parser.rb
+++ b/lib/chronic/parser.rb
@@ -47,7 +47,9 @@ module Chronic
     #                 future, `now - x years` is assumed to be the past.
     def initialize(options = {})
       @options = DEFAULT_OPTIONS.merge(options)
-      @now = options.delete(:now) || Chronic.time_class.now
+      now = options.delete(:now)
+      now = Chronic.parse(now) if now.is_a?(String)
+      @now = now || Chronic.time_class.now
     end
 
     # Parse "text" with the given options

--- a/test/test_parsing.rb
+++ b/test/test_parsing.rb
@@ -1192,6 +1192,11 @@ class TestParsing < TestCase
     assert_equal pre_normalize("8:00 pm February 11"), pre_normalize("8:00 p.m. February 11")
   end
 
+  def test_handle_string_as_now_option
+    time = Chronic.parse("3rd thursday this november", :now => "1/10/2010")
+    assert_equal Time.local(2010, 11, 18, 12), time
+  end
+
   private
   def parse_now(string, options={})
     Chronic.parse(string, {:now => TIME_2006_08_16_14_00_00 }.merge(options))


### PR DESCRIPTION
So one can do

``` ruby
Chronic.parse "3rd thursday this november", :now => "1/10/2010"
```
