### PR TITLE
Support `ActiveSupport::TimeZone` as `Chronic.time_class` (fixes #208)

### DIFF
--- a/chronic.gemspec
+++ b/chronic.gemspec
@@ -19,4 +19,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'minitest', '~> 5.0'
+  s.add_development_dependency 'activesupport'
 end

--- a/lib/chronic.rb
+++ b/lib/chronic.rb
@@ -137,8 +137,14 @@ module Chronic
         month = month % 12
       end
     end
-    offset = Time::normalize_offset(offset) if Chronic.time_class.is_a?(DateTime)
-    Chronic.time_class.new(year, month, day, hour, minute, second, offset)
+    if Chronic.time_class.name == "Date"
+      Chronic.time_class.new(year, month, day)
+    elsif not Chronic.time_class.respond_to?(:new)
+      Chronic.time_class.local(year, month, day, hour, minute, second)
+    else
+      offset = Time::normalize_offset(offset) if Chronic.time_class.name == "DateTime"
+      Chronic.time_class.new(year, month, day, hour, minute, second, offset)
+    end
   end
 
 end

--- a/test/test_chronic.rb
+++ b/test/test_chronic.rb
@@ -129,4 +129,55 @@ class TestChronic < TestCase
     assert_equal Time.local(2005, 12), Chronic.construct(2000, 72)
   end
 
+  def test_time
+    org = Chronic.time_class
+    begin
+      Chronic.time_class = ::Time
+      assert_equal ::Time.new(2013, 8, 27, 20, 30, 40, '+05:30'), Chronic.construct(2013, 8, 27, 20, 30, 40, '+05:30')
+      assert_equal ::Time.new(2013, 8, 27, 20, 30, 40, '-08:00'), Chronic.construct(2013, 8, 27, 20, 30, 40, -28800)
+    ensure
+      Chronic.time_class = org
+    end
+  end
+
+  def test_date
+    org = Chronic.time_class
+    begin
+      Chronic.time_class = ::Date
+      assert_equal Date.new(2013, 8, 27), Chronic.construct(2013, 8, 27)
+    ensure
+      Chronic.time_class = org
+    end
+  end
+
+  def test_datetime
+    org = Chronic.time_class
+    begin
+      Chronic.time_class = ::DateTime
+      assert_equal DateTime.new(2013, 8, 27, 20, 30, 40, '+05:30'), Chronic.construct(2013, 8, 27, 20, 30, 40, '+05:30')
+      assert_equal DateTime.new(2013, 8, 27, 20, 30, 40, '-08:00'), Chronic.construct(2013, 8, 27, 20, 30, 40, -28800)
+    ensure
+      Chronic.time_class = org
+    end
+  end
+
+  def test_activesupport
+=begin
+    # ActiveSupport needs MiniTest '~> 4.2' which conflicts with '~> 5.0'
+    require 'active_support/time'
+    org = Chronic.time_class
+    org_zone = ::Time.zone
+    begin
+      ::Time.zone = "Tokyo"
+      Chronic.time_class = ::Time.zone
+      assert_equal Time.new(2013, 8, 27, 20, 30, 40, '+09:00'), Chronic.construct(2013, 8, 27, 20, 30, 40)
+      ::Time.zone = "Indiana (East)"
+      Chronic.time_class = ::Time.zone
+      assert_equal Time.new(2013, 8, 27, 20, 30, 40, -14400), Chronic.construct(2013, 8, 27, 20, 30, 40)
+    ensure
+      Chronic.time_class = org
+      ::Time.zone = org_zone
+    end
+=end
+  end
 end


### PR DESCRIPTION
Finally done :) It took way more time than should. For some reason `is_a?`, `kind_of?`, `instance_of?` didn't worked in tests, but did work if I just run manually, seems `MiniTest` does some bad monkey patching or something else overrides something. So I'm using `time_class.name` to determine class.

Also I commented out ActiveSupport test because it requires `MiniTest ~> 4.2` but we're using `~> 5.0`. Have to wait till they update and then can comment out.
