### PR TITLE
Ruby 1.8 compatibility

### DIFF
--- a/lib/chronic.rb
+++ b/lib/chronic.rb
@@ -139,7 +139,7 @@ module Chronic
     end
     if Chronic.time_class.name == "Date"
       Chronic.time_class.new(year, month, day)
-    elsif not Chronic.time_class.respond_to?(:new)
+    elsif not Chronic.time_class.respond_to?(:new) or (RUBY_VERSION.to_f < 1.9 and Chronic.time_class.name == "Time")
       Chronic.time_class.local(year, month, day, hour, minute, second)
     else
       offset = Time::normalize_offset(offset) if Chronic.time_class.name == "DateTime"

--- a/lib/chronic/parser.rb
+++ b/lib/chronic/parser.rb
@@ -90,7 +90,7 @@ module Chronic
       text = text.to_s.downcase
       text.gsub!(/\b(\d{2})\.(\d{2})\.(\d{4})\b/, '\3 / \2 / \1')
       text.gsub!(/\b([ap])\.m\.?/, '\1m')
-      text.gsub!(/(?<=:\d{2}|:\d{2}\.\d{3})\-(\d{2}:?\d{2})\b/, 'tzminus\1')
+      text.gsub!(/(\s+|:\d{2}|:\d{2}\.\d{3})\-(\d{2}:?\d{2})\b/, '\1tzminus\2')
       text.gsub!(/\./, ':')
       text.gsub!(/([ap]):m:?/, '\1m')
       text.gsub!(/['"]/, '')

--- a/test/test_parsing.rb
+++ b/test/test_parsing.rb
@@ -180,6 +180,9 @@ class TestParsing < TestCase
     time = parse_now("2011-07-03 22:11:35 +01:00")
     assert_equal 1309727495, time.to_i
 
+    time = parse_now("2011-07-03 16:11:35 -05:00")
+    assert_equal 1309727495, time.to_i
+
     time = parse_now("2011-07-03 21:11:35 UTC")
     assert_equal 1309727495, time.to_i
 


### PR DESCRIPTION
Don't use regex's lookbehind as it's not supported in Ruby 1.8

On phone now so I haven't tested but I think it should work. No idea why I didn't thought about this earlier - we don't really need to use lookbehind. It's trivial. Fixes #211
