### PR TITLE
Allow weeks to start on monday

### DIFF
--- a/lib/chronic/parser.rb
+++ b/lib/chronic/parser.rb
@@ -9,6 +9,7 @@ module Chronic
       :context => :future,
       :now => nil,
       :hours24 => nil,
+      :week_start => :sunday,
       :guess => true,
       :ambiguous_time_range => 6,
       :endian_precedence    => [:middle, :little],
@@ -25,6 +26,9 @@ module Chronic
     #        :now - Time, all computations will be based off of time
     #               instead of Time.now.
     #        :hours24 - Time will be parsed as it would be 24 hour clock.
+    #        :week_start - By default, the parser assesses weeks start on
+    #                  sunday but you can change this value to :monday if
+    #                  needed.
     #        :guess - By default the parser will guess a single point in time
     #                 for the given date or time. If you'd rather have the
     #                 entire time span returned, set this to false

--- a/lib/chronic/repeaters/repeater_week.rb
+++ b/lib/chronic/repeaters/repeater_week.rb
@@ -4,6 +4,7 @@ module Chronic
 
     def initialize(type, options = {})
       super
+      @repeater_day_name = options[:week_start] || :sunday
       @current_week_start = nil
     end
 
@@ -13,16 +14,16 @@ module Chronic
       unless @current_week_start
         case pointer
         when :future
-          sunday_repeater = RepeaterDayName.new(:sunday)
-          sunday_repeater.start = @now
-          next_sunday_span = sunday_repeater.next(:future)
-          @current_week_start = next_sunday_span.begin
+          first_week_day_repeater = RepeaterDayName.new(@repeater_day_name)
+          first_week_day_repeater.start = @now
+          next_span = first_week_day_repeater.next(:future)
+          @current_week_start = next_span.begin
         when :past
-          sunday_repeater = RepeaterDayName.new(:sunday)
-          sunday_repeater.start = (@now + RepeaterDay::DAY_SECONDS)
-          sunday_repeater.next(:past)
-          last_sunday_span = sunday_repeater.next(:past)
-          @current_week_start = last_sunday_span.begin
+          first_week_day_repeater = RepeaterDayName.new(@repeater_day_name)
+          first_week_day_repeater.start = (@now + RepeaterDay::DAY_SECONDS)
+          first_week_day_repeater.next(:past)
+          last_span = first_week_day_repeater.next(:past)
+          @current_week_start = last_span.begin
         end
       else
         direction = pointer == :future ? 1 : -1
@@ -38,23 +39,23 @@ module Chronic
       case pointer
       when :future
         this_week_start = Chronic.time_class.local(@now.year, @now.month, @now.day, @now.hour) + RepeaterHour::HOUR_SECONDS
-        sunday_repeater = RepeaterDayName.new(:sunday)
-        sunday_repeater.start = @now
-        this_sunday_span = sunday_repeater.this(:future)
-        this_week_end = this_sunday_span.begin
+        first_week_day_repeater = RepeaterDayName.new(@repeater_day_name)
+        first_week_day_repeater.start = @now
+        this_span = first_week_day_repeater.this(:future)
+        this_week_end = this_span.begin
         Span.new(this_week_start, this_week_end)
       when :past
         this_week_end = Chronic.time_class.local(@now.year, @now.month, @now.day, @now.hour)
-        sunday_repeater = RepeaterDayName.new(:sunday)
-        sunday_repeater.start = @now
-        last_sunday_span = sunday_repeater.next(:past)
-        this_week_start = last_sunday_span.begin
+        first_week_day_repeater = RepeaterDayName.new(@repeater_day_name)
+        first_week_day_repeater.start = @now
+        last_span = first_week_day_repeater.next(:past)
+        this_week_start = last_span.begin
         Span.new(this_week_start, this_week_end)
       when :none
-        sunday_repeater = RepeaterDayName.new(:sunday)
-        sunday_repeater.start = @now
-        last_sunday_span = sunday_repeater.next(:past)
-        this_week_start = last_sunday_span.begin
+        first_week_day_repeater = RepeaterDayName.new(@repeater_day_name)
+        first_week_day_repeater.start = @now
+        last_span = first_week_day_repeater.next(:past)
+        this_week_start = last_span.begin
         Span.new(this_week_start, this_week_start + WEEK_SECONDS)
       end
     end

--- a/test/test_parsing.rb
+++ b/test/test_parsing.rb
@@ -647,6 +647,12 @@ class TestParsing < TestCase
     time = parse_now("this week", :context => :past)
     assert_equal Time.local(2006, 8, 14, 19), time
 
+    time = parse_now("this week", :context => :past, :guess => :begin)
+    assert_equal Time.local(2006, 8, 13), time
+
+    time = parse_now("this week", :context => :past, :guess => :begin, :week_start => :monday)
+    assert_equal Time.local(2006, 8, 14), time
+
     # weekend
 
     time = parse_now("this weekend")

--- a/test/test_repeater_week.rb
+++ b/test/test_repeater_week.rb
@@ -59,4 +59,57 @@ class TestRepeaterWeek < TestCase
     assert_equal Time.local(2006, 9, 6, 14, 0, 1), offset_span.end
   end
 
+  def test_next_future_starting_on_monday
+    weeks = Chronic::RepeaterWeek.new(:week, :week_start => :monday)
+    weeks.start = @now
+
+    next_week = weeks.next(:future)
+    assert_equal Time.local(2006, 8, 21), next_week.begin
+    assert_equal Time.local(2006, 8, 28), next_week.end
+
+    next_next_week = weeks.next(:future)
+    assert_equal Time.local(2006, 8, 28), next_next_week.begin
+    assert_equal Time.local(2006, 9, 4), next_next_week.end
+  end
+
+  def test_next_past_starting_on_monday
+    weeks = Chronic::RepeaterWeek.new(:week, :week_start => :monday)
+    weeks.start = @now
+
+    last_week = weeks.next(:past)
+    assert_equal Time.local(2006, 8, 7), last_week.begin
+    assert_equal Time.local(2006, 8, 14), last_week.end
+
+    last_last_week = weeks.next(:past)
+    assert_equal Time.local(2006, 7, 31), last_last_week.begin
+    assert_equal Time.local(2006, 8, 7), last_last_week.end
+  end
+
+  def test_this_future_starting_on_monday
+    weeks = Chronic::RepeaterWeek.new(:week, :week_start => :monday)
+    weeks.start = @now
+
+    this_week = weeks.this(:future)
+    assert_equal Time.local(2006, 8, 16, 15), this_week.begin
+    assert_equal Time.local(2006, 8, 21), this_week.end
+  end
+
+  def test_this_past_starting_on_monday
+    weeks = Chronic::RepeaterWeek.new(:week, :week_start => :monday)
+    weeks.start = @now
+
+    this_week = weeks.this(:past)
+    assert_equal Time.local(2006, 8, 14, 0), this_week.begin
+    assert_equal Time.local(2006, 8, 16, 14), this_week.end
+  end
+
+  def test_offset_starting_on_monday
+    weeks = Chronic::RepeaterWeek.new(:week, :week_start => :monday)
+
+    span = Chronic::Span.new(@now, @now + 1)
+    offset_span = weeks.offset(span, 3, :future)
+
+    assert_equal Time.local(2006, 9, 6, 14), offset_span.begin
+    assert_equal Time.local(2006, 9, 6, 14, 0, 1), offset_span.end
+  end
 end


### PR DESCRIPTION
By default, the parser assesses weeks start on sunday.

This pull request adds a `weeks_start` options to Chronic that can be set to `:monday` (or any other day if appropriate) in order to customize the first day of the week.
