### PR TITLE
Holiday Days implementation, starting with Christmas!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /coverage/
 /doc/
 /tags/
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gemspec

--- a/lib/chronic/parser.rb
+++ b/lib/chronic/parser.rb
@@ -92,6 +92,7 @@ module Chronic
     # Returns a new String ready for Chronic to parse.
     def pre_normalize(text)
       text = text.to_s.downcase
+      text.gsub!(/([xX]+mas|[cC]+hristmas)/, 'december 25th')
       text.gsub!(/\b(\d{2})\.(\d{2})\.(\d{4})\b/, '\3 / \2 / \1')
       text.gsub!(/\b([ap])\.m\.?/, '\1m')
       text.gsub!(/(\s+|:\d{2}|:\d{2}\.\d{3})\-(\d{2}:?\d{2})\b/, '\1tzminus\2')

--- a/test/test_parsing.rb
+++ b/test/test_parsing.rb
@@ -1227,6 +1227,12 @@ class TestParsing < TestCase
     assert_equal Time.local(2005, 12, 30, 12), time
   end
 
+  def test_handle_holiday_days
+    Chronic.debug
+    time = Chronic.parse("christmas 2012")
+    assert_equal Time.utc(2012, 12, 25, 12), time
+  end
+
   def test_normalizing_day_portions
     assert_equal pre_normalize("8:00 pm February 11"), pre_normalize("8:00 p.m. February 11")
   end

--- a/test/test_parsing.rb
+++ b/test/test_parsing.rb
@@ -1227,16 +1227,50 @@ class TestParsing < TestCase
     assert_equal Time.local(2005, 12, 30, 12), time
   end
 
-  def test_handle_christmas
+  def test_handle_christmas_solo
     time = Chronic.parse("xmas", :now => Time.local(2007))
     assert_equal Time.utc(2007, 12, 25, 12), time
 
+    time = Chronic.parse("Christmas", :now => Time.local(2007))
+    assert_equal Time.utc(2007, 12, 25, 12), time
+
+    time = Chronic.parse("christmas", :now => Time.local(2007))
+    assert_equal Time.utc(2007, 12, 25, 12), time
+
+    time = Chronic.parse("Xmas", :now => Time.local(2007))
+    assert_equal Time.utc(2007, 12, 25, 12), time
+  end
+
+  def test_handle_christmas_years
     time = Chronic.parse("xmas 2005")
     assert_equal Time.utc(2005, 12, 25, 12), time
 
-    time = Chronic.parse("xmas 2013")
+    time = Chronic.parse("Xmas 2005")
+    assert_equal Time.utc(2005, 12, 25, 12), time
+
+    time = Chronic.parse("christmas 2013")
+    assert_equal Time.utc(2013, 12, 25, 12), time
+
+    time = Chronic.parse("Christmas 2013")
     assert_equal Time.utc(2013, 12, 25, 12), time
   end
+
+  def test_handle_christmas_future
+    time = Chronic.parse("next christmas", :now => Time.local(2007))
+    assert_equal Time.utc(2007, 12, 25, 12), time
+
+    time = Chronic.parse("xmas next year", :now => Time.local(2005))
+    assert_equal Time.utc(2006, 12, 25, 12), time
+  end
+
+  def test_handle_christmas_past
+    time = Chronic.parse("last christmas", :now => Time.local(2007))
+    assert_equal Time.utc(2006, 12, 25, 12), time
+
+    time = Chronic.parse("xmas last year", :now => Time.local(2005))
+    assert_equal Time.utc(2004, 12, 25, 12), time
+  end
+
 
   def test_normalizing_day_portions
     assert_equal pre_normalize("8:00 pm February 11"), pre_normalize("8:00 p.m. February 11")

--- a/test/test_parsing.rb
+++ b/test/test_parsing.rb
@@ -1227,10 +1227,15 @@ class TestParsing < TestCase
     assert_equal Time.local(2005, 12, 30, 12), time
   end
 
-  def test_handle_holiday_days
-    Chronic.debug
-    time = Chronic.parse("christmas 2012")
-    assert_equal Time.utc(2012, 12, 25, 12), time
+  def test_handle_christmas
+    time = Chronic.parse("xmas", :now => Time.local(2007))
+    assert_equal Time.utc(2007, 12, 25, 12), time
+
+    time = Chronic.parse("xmas 2005")
+    assert_equal Time.utc(2005, 12, 25, 12), time
+
+    time = Chronic.parse("xmas 2013")
+    assert_equal Time.utc(2013, 12, 25, 12), time
   end
 
   def test_normalizing_day_portions


### PR DESCRIPTION
Tis' the season! :christmas_tree:  

Currently the implementation works with a given year or on it's own, but fails for `next` and `last`

Not sure how to handle those...

Any thoughts?
