### PR TITLE
Fix Chronic.parse('t') raising NoMethodError

### DIFF
--- a/lib/chronic/repeater.rb
+++ b/lib/chronic/repeater.rb
@@ -60,7 +60,7 @@ module Chronic
       scan_for token, RepeaterDayName,
       {
         /^m[ou]n(day)?$/ => :monday,
-        /^t(ue|eu|oo|u|)s?(day)?$/ => :tuesday,
+        /^t(ue|eu|oo|u)s?(day)?$/ => :tuesday,
         /^we(d|dnes|nds|nns)(day)?$/ => :wednesday,
         /^th(u|ur|urs|ers)(day)?$/ => :thursday,
         /^fr[iy](day)?$/ => :friday,

--- a/test/test_parsing.rb
+++ b/test/test_parsing.rb
@@ -1012,6 +1012,9 @@ class TestParsing < TestCase
 
     time = parse_now("Ham Sandwich")
     assert_equal nil, time
+
+    time = parse_now("t")
+    assert_equal nil, time
   end
 
   def test_parse_span


### PR DESCRIPTION
't' used to match both repeater-dayname-tuesday & separator-T, so would end up passing an empty token array to `handler.invoke(:anchor, good_tokens, self, options)` in Parser#tokens_to_span

( I assume a single 't' wasn't intended to match Tuesday ? )
