### PR TITLE
Don't mutate Token#word when inspecting tokens

### DIFF
--- a/lib/chronic/token.rb
+++ b/lib/chronic/token.rb
@@ -41,7 +41,7 @@ module Chronic
 
     # Print this Token in a pretty way
     def to_s
-      @word << '(' << @tags.join(', ') << ') '
+      @word + '(' + @tags.join(', ') + ') '
     end
 
     def inspect

--- a/test/test_token.rb
+++ b/test/test_token.rb
@@ -22,4 +22,10 @@ class TestToken < TestCase
     assert_equal 'foo', token.word
   end
 
+  def test_token_inspect_doesnt_mutate_the_word
+    token = Chronic::Token.new('foo')
+    token.inspect
+    assert_equal 'foo', token.word
+  end
+
 end


### PR DESCRIPTION
Just a minor thing, but while debugging something else I kept running into Token#word changing when it got inspected in IRB
