### PR TITLE
fixed issue when dealing with dates without given year, that lays in past

### DIFF
--- a/lib/chronic/handlers.rb
+++ b/lib/chronic/handlers.rb
@@ -8,6 +8,7 @@ module Chronic
       span = month.this(options[:context])
       year, month = span.begin.year, span.begin.month
       day_start = Chronic.time_class.local(year, month, day)
+      day_start = Chronic.time_class.local(year + 1, month, day) if options[:context] == :future && day_start < now
 
       day_or_time(day_start, time_tokens, options)
     end

--- a/test/test_parsing.rb
+++ b/test/test_parsing.rb
@@ -41,13 +41,13 @@ class TestParsing < TestCase
 
   def test_handle_rmn_sd
     time = parse_now("aug 3")
-    assert_equal Time.local(2006, 8, 3, 12), time
+    assert_equal Time.local(2007, 8, 3, 12), time
 
     time = parse_now("aug 3", :context => :past)
     assert_equal Time.local(2006, 8, 3, 12), time
 
     time = parse_now("aug. 3")
-    assert_equal Time.local(2006, 8, 3, 12), time
+    assert_equal Time.local(2007, 8, 3, 12), time
 
     time = parse_now("aug 20")
     assert_equal Time.local(2006, 8, 20, 12), time
@@ -107,7 +107,7 @@ class TestParsing < TestCase
 
   def test_handle_od_rm
     time = parse_now("fifteenth of this month")
-    assert_equal Time.local(2006, 8, 15, 12), time
+    assert_equal Time.local(2007, 8, 15, 12), time
   end
 
   def test_handle_od_rmn


### PR DESCRIPTION
As in the tests: Time.now == 2006/8/16
Chronic.parse("8/8") -> 2007/8/8
Before the change, Chronic.parse("aug 8") will return 2006/8/8 - which is not the same result as for "8/8".

Fixed the issue and modified some tests.
