### PR TITLE
Dealing with cases like '2 Nov 10'

### DIFF
--- a/lib/chronic/definition.rb
+++ b/lib/chronic/definition.rb
@@ -107,7 +107,8 @@ module Chronic
         Handler.new([:scalar_month, [:separator_slash, :separator_dash], :scalar_day, [:separator_slash, :separator_dash], :scalar_year, :separator_at?, 'time?'], :handle_sm_sd_sy),
         Handler.new([:scalar_month, [:separator_slash, :separator_dash], :scalar_day, :separator_at?, 'time?'], :handle_sm_sd),
         Handler.new([:scalar_day, [:separator_slash, :separator_dash], :scalar_month, :separator_at?, 'time?'], :handle_sd_sm),
-        Handler.new([:scalar_day, [:separator_slash, :separator_dash], :scalar_month, [:separator_slash, :separator_dash], :scalar_year, :separator_at?, 'time?'], :handle_sd_sm_sy)
+        Handler.new([:scalar_day, [:separator_slash, :separator_dash], :scalar_month, [:separator_slash, :separator_dash], :scalar_year, :separator_at?, 'time?'], :handle_sd_sm_sy),
+        Handler.new([:scalar_day, :repeater_month_name, :scalar_year, :separator_at?, 'time?'], :handle_sd_rmn_sy)
       ]
 
       case endian = Array(options[:endian_precedence]).first

--- a/test/test_chronic.rb
+++ b/test/test_chronic.rb
@@ -61,7 +61,8 @@ class TestChronic < TestCase
       Chronic::Handler.new([:scalar_month, [:separator_slash, :separator_dash], :scalar_day, [:separator_slash, :separator_dash], :scalar_year, :separator_at?, 'time?'], :handle_sm_sd_sy),
       Chronic::Handler.new([:scalar_month, [:separator_slash, :separator_dash], :scalar_day, :separator_at?, 'time?'], :handle_sm_sd),
       Chronic::Handler.new([:scalar_day, [:separator_slash, :separator_dash], :scalar_month, :separator_at?, 'time?'], :handle_sd_sm),
-      Chronic::Handler.new([:scalar_day, [:separator_slash, :separator_dash], :scalar_month, [:separator_slash, :separator_dash], :scalar_year, :separator_at?, 'time?'], :handle_sd_sm_sy)
+      Chronic::Handler.new([:scalar_day, [:separator_slash, :separator_dash], :scalar_month, [:separator_slash, :separator_dash], :scalar_year, :separator_at?, 'time?'], :handle_sd_sm_sy),
+      Chronic::Handler.new([:scalar_day, :repeater_month_name, :scalar_year, :separator_at?, 'time?'], :handle_sd_rmn_sy)
     ]
 
     assert_equal endians, Chronic::SpanDictionary.new.definitions[:endian]

--- a/test/test_parsing.rb
+++ b/test/test_parsing.rb
@@ -283,6 +283,15 @@ class TestParsing < TestCase
 
     time = parse_now("27 Oct 2006 7:30pm")
     assert_equal Time.local(2006, 10, 27, 19, 30), time
+
+    time = parse_now("3 jan 10")
+    assert_equal Time.local(2010, 1, 3, 12), time
+
+    time = parse_now("3 jan 10", :endian_precedence => :little)
+    assert_equal Time.local(2010, 1, 3, 12), time
+
+    time = parse_now("3 jan 10", :endian_precedence => :middle)
+    assert_equal Time.local(2010, 1, 3, 12), time
   end
 
   def test_handle_sm_sd_sy


### PR DESCRIPTION
Sometimes separators like slashes or dashes are not present and
still the date is 'readable': parsing '2 Nov 10' should be the
same than parsing 'Nov 2nd, 2010', isn't it?
