### PR TITLE
Added parser support for "midday"

### DIFF
--- a/lib/chronic/parser.rb
+++ b/lib/chronic/parser.rb
@@ -108,7 +108,7 @@ module Chronic
       text.gsub!(/\btoday\b/, 'this day')
       text.gsub!(/\btomm?orr?ow\b/, 'next day')
       text.gsub!(/\byesterday\b/, 'last day')
-      text.gsub!(/\bnoon\b/, '12:00pm')
+      text.gsub!(/\bnoon|midday\b/, '12:00pm')
       text.gsub!(/\bmidnight\b/, '24:00')
       text.gsub!(/\bnow\b/, 'this second')
       text.gsub!('quarter', '15')

--- a/test/test_parsing.rb
+++ b/test/test_parsing.rb
@@ -1234,6 +1234,10 @@ class TestParsing < TestCase
     assert_equal pre_normalize("8:00 pm February 11"), pre_normalize("8:00 p.m. February 11")
   end
 
+  def test_normalizing_time_of_day_phrases
+    assert_equal pre_normalize("midday February 11"), pre_normalize("12:00 p.m. February 11")
+  end
+
   private
   def parse_now(string, options={})
     Chronic.parse(string, {:now => TIME_2006_08_16_14_00_00 }.merge(options))


### PR DESCRIPTION
The parser currently recognises "noon" but not "midday". I'd added support for this phrase, and a unit test too.
