### PR TITLE
Create version file and use it for Rakefile, instead of parsing with regexp...

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,11 +1,12 @@
-require 'date'
+$:.unshift File.expand_path('../lib', __FILE__)
+require 'chronic/version'
 
 def version
-  contents = File.read File.expand_path('../lib/chronic.rb', __FILE__)
-  contents[/VERSION = "([^"]+)"/, 1]
+  Chronic::VERSION
 end
 
 def do_test
+  require 'chronic'
   $:.unshift './test'
   Dir.glob('test/test_*.rb').each { |t| require File.basename(t) }
 end
@@ -21,14 +22,15 @@ def open_command
   end
 end
 
+desc 'Run tests'
 task :test do
   do_test
 end
 
-desc "Generate SimpleCov test coverage and open in your browser"
+desc 'Generate SimpleCov test coverage and open in your browser'
 task :coverage do
   require 'simplecov'
-  FileUtils.rm_rf("./coverage")
+  FileUtils.rm_rf('./coverage')
   SimpleCov.command_name 'Unit Tests'
   SimpleCov.at_exit do
     SimpleCov.result.format!
@@ -38,9 +40,9 @@ task :coverage do
   do_test
 end
 
-desc "Open an irb session preloaded with this library"
+desc 'Open an irb session preloaded with this library'
 task :console do
-  sh "irb -Ilib -rchronic"
+  sh 'irb -Ilib -rchronic'
 end
 
 desc "Release Chronic version #{version}"
@@ -56,10 +58,10 @@ task :release => :build do
   sh "gem push pkg/chronic-#{version}.gem"
 end
 
-desc "Build a gem from the gemspec"
+desc 'Build a gem from the gemspec'
 task :build do
-  FileUtils.mkdir_p "pkg"
-  sh "gem build chronic.gemspec"
+  FileUtils.mkdir_p 'pkg'
+  sh 'gem build chronic.gemspec'
   FileUtils.mv("./chronic-#{version}.gem", "pkg")
 end
 

--- a/chronic.gemspec
+++ b/chronic.gemspec
@@ -1,5 +1,5 @@
 $:.unshift File.expand_path('../lib', __FILE__)
-require 'chronic'
+require 'chronic/version'
 
 Gem::Specification.new do |s|
   s.name = 'chronic'
@@ -18,8 +18,8 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'numerizer', '~> 0.2'
 
-  s.add_development_dependency 'rake'
-  s.add_development_dependency 'simplecov'
+  s.add_development_dependency 'rake', '~> 10'
+  s.add_development_dependency 'simplecov', '~> 0'
   s.add_development_dependency 'minitest', '~> 5.0'
-  s.add_development_dependency 'activesupport'
+  s.add_development_dependency 'activesupport', '~> 4'
 end

--- a/lib/chronic.rb
+++ b/lib/chronic.rb
@@ -2,6 +2,8 @@ require 'time'
 require 'date'
 require 'numerizer'
 
+require 'chronic/version'
+
 require 'chronic/parser'
 require 'chronic/date'
 require 'chronic/time'
@@ -54,7 +56,6 @@ require 'chronic/repeaters/repeater_time'
 #   Chronic.parse('monday', :context => :past)
 #     #=> Mon Aug 21 12:00:00 PDT 2006
 module Chronic
-  VERSION = '0.10.2'
 
   class << self
 

--- a/lib/chronic/version.rb
+++ b/lib/chronic/version.rb
@@ -1,0 +1,3 @@
+module Chronic
+  VERSION = '0.10.2'
+end


### PR DESCRIPTION
Create `version.rb` file for version info, like typically gems do. Advantages are that doesn't have to include everything just to see current version, for example in gemspec. Also in Rakefile use this file, instead of manually parsing with regexp.

Also added dependency versions to gemspec to avoid warning (about how it's not recommended) when building gem.
