### PR TITLE
Fix the gemspec loading order of dependencies

### DIFF
--- a/chronic.gemspec
+++ b/chronic.gemspec
@@ -1,5 +1,5 @@
 $:.unshift File.expand_path('../lib', __FILE__)
-require 'chronic'
+require 'chronic/version'
 
 Gem::Specification.new do |s|
   s.name = 'chronic'

--- a/lib/chronic/version.rb
+++ b/lib/chronic/version.rb
@@ -1,0 +1,3 @@
+module Chronic
+  VERSION = '0.10.2'
+end


### PR DESCRIPTION
Was getting the following type of errors when running bundle:

```
There was a LoadError while loading chronic.gemspec: 
cannot load such file -- numerizer from
  /opt/rubies/2.1.1/lib/ruby/gems/2.1.0/bundler/gems/chronic-cd739fdf316d/chronic.gemspec:2:in `<main>'

Does it try to require a relative path? That's been removed in Ruby 1.9.
```

This removes the need for the entire library to be loaded when parsing the gemspec
