### PR TITLE
Milliseconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ Specific Times (many of the above with an added time)
 * 22nd of june at 8am
 * 1979-05-27 05:00:00
 * 03/01/2012 07:25:09.234567
+* 2013-08-01T19:30:00.345-07:00
+* 2013-08-01T19:30:00.34-07:00
 * etc
 
 

--- a/lib/chronic/parser.rb
+++ b/lib/chronic/parser.rb
@@ -155,7 +155,6 @@ module Chronic
     private
 
     def tokenize(text, options)
-      # require 'pry'; binding.pry
       text = pre_normalize(text)
       tokens = text.split(' ').map { |word| Token.new(word) }
       [Repeater, Grabber, Pointer, Scalar, Ordinal, Separator, Sign, TimeZone].each do |tok|

--- a/lib/chronic/parser.rb
+++ b/lib/chronic/parser.rb
@@ -95,7 +95,7 @@ module Chronic
       text = text.to_s.downcase
       text.gsub!(/\b(\d{2})\.(\d{2})\.(\d{4})\b/, '\3 / \2 / \1')
       text.gsub!(/\b([ap])\.m\.?/, '\1m')
-      text.gsub!(/(\s+|:\d{2}|:\d{2}\.\d{3})\-(\d{2}:?\d{2})\b/, '\1tzminus\2')
+      text.gsub!(/(\s+|:\d{2}|:\d{2}\.\d+)\-(\d{2}:?\d{2})\b/, '\1tzminus\2')
       text.gsub!(/\./, ':')
       text.gsub!(/([ap]):m:?/, '\1m')
       text.gsub!(/['"]/, '')
@@ -155,6 +155,7 @@ module Chronic
     private
 
     def tokenize(text, options)
+      # require 'pry'; binding.pry
       text = pre_normalize(text)
       tokens = text.split(' ').map { |word| Token.new(word) }
       [Repeater, Grabber, Pointer, Scalar, Ordinal, Separator, Sign, TimeZone].each do |tok|

--- a/test/test_parsing.rb
+++ b/test/test_parsing.rb
@@ -22,6 +22,14 @@ class TestParsing < TestCase
     time2 = Time.parse("2013-08-01 019:30:00.345-07:00")
     assert_in_delta time, time2, 0.001
 
+    time = Chronic.parse("2013-08-01T19:30:00.34-07:00")
+    time2 = Time.parse("2013-08-01T19:30:00.34-07:00")
+    assert_in_delta time, time2, 0.001
+
+    time = Chronic.parse("2013-08-01T19:30:00.3456789-07:00")
+    time2 = Time.parse("2013-08-01T19:30:00.3456789-07:00")
+    assert_in_delta time, time2, 0.001
+
     time = Chronic.parse("2012-08-02T12:00:00Z")
     assert_equal Time.utc(2012, 8, 2, 12), time
 


### PR DESCRIPTION
I ran into the case in which Chronic was only able to parse the string format if the milliseconds contained 3 digits.

example: 
`"2013-08-01T19:30:00.34-07:00"` would return nil
`"2013-08-01T19:30:00.340-07:00"` would return 2013-08-01 22:30:00 -0400

https://github.com/mojombo/chronic/issues/242
