### PR TITLE
Add Ruby 2.0.0 and Ruby 2.1.2 to Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: ruby
 rvm:
+  - 2.1
+  - 2.0.0
   - 1.9.3
-  - 1.9.2
-  - 1.8.7
   - jruby-19mode
-  - jruby-18mode
-  - rbx-19mode
+  - rbx-2


### PR DESCRIPTION
Would be great to know that Ruby 2.1.2 is supported.