### PR TITLE
Raise error on unsupported options

### DIFF
--- a/lib/chronic/parser.rb
+++ b/lib/chronic/parser.rb
@@ -55,6 +55,7 @@ module Chronic
     #                 two digit year is `now + x years` it's assumed to be the
     #                 future, `now - x years` is assumed to be the past.
     def initialize(options = {})
+      validate_options!(options)
       @options = DEFAULT_OPTIONS.merge(options)
       @now = options.delete(:now) || Chronic.time_class.now
     end
@@ -153,6 +154,14 @@ module Chronic
     end
 
     private
+
+
+    def validate_options!(options)
+      given = options.keys.map(&:to_s).sort
+      allowed = DEFAULT_OPTIONS.keys.map(&:to_s).sort
+      non_permitted = given - allowed
+      raise ArgumentError, "Unsupported option(s): #{non_permitted.join(', ')}" if non_permitted.any?
+    end
 
     def tokenize(text, options)
       text = pre_normalize(text)

--- a/test/test_chronic.rb
+++ b/test/test_chronic.rb
@@ -162,6 +162,25 @@ class TestChronic < TestCase
     end
   end
 
+  def test_valid_options
+    options = {
+      :context => :future,
+      :now => nil,
+      :hours24 => nil,
+      :week_start => :sunday,
+      :guess => true,
+      :ambiguous_time_range => 6,
+      :endian_precedence    => [:middle, :little],
+      :ambiguous_year_future_bias => 50
+    }
+    refute_nil Chronic.parse('now', options)
+  end
+
+  def test_invalid_options
+    assert_raises(ArgumentError) { Chronic.parse('now', foo: 'boo') }
+    assert_raises(ArgumentError) { Chronic.parse('now', time_class: Time) }
+  end
+
   def test_activesupport
 =begin
     # ActiveSupport needs MiniTest '~> 4.2' which conflicts with '~> 5.0'


### PR DESCRIPTION
Theis will be usefull to eliminate all
the possible confusion going on what options
are and are not supported by chronic.

One such example is:
https://github.com/mojombo/chronic/issues/182#issuecomment-47094623

It is a good idea to tell people know about it in advance
if they provide invalid or unsupported options.
