### PR TITLE
Add support for rmn_s_r_p pattern

### DIFF
--- a/lib/chronic/definition.rb
+++ b/lib/chronic/definition.rb
@@ -78,6 +78,7 @@ module Chronic
   class ArrowDefinitions < SpanDefinitions
     def definitions
       [
+        Handler.new([:repeater_month_name, :scalar, :repeater, :pointer], :handle_rmn_s_r_p),
         Handler.new([:scalar, :repeater, :pointer], :handle_s_r_p),
         Handler.new([:scalar, :repeater, :separator_and?, :scalar, :repeater, :pointer, :separator_at?, 'anchor'], :handle_s_r_a_s_r_p_a),
         Handler.new([:pointer, :scalar, :repeater], :handle_p_s_r),

--- a/lib/chronic/handlers.rb
+++ b/lib/chronic/handlers.rb
@@ -451,6 +451,11 @@ module Chronic
       handle_srp(tokens, anchor_span, options)
     end
 
+    # Handle repeater/scalar/repeater/pointer
+    def handle_rmn_s_r_p(tokens, options)
+      handle_s_r_p_a(tokens[1..3] + tokens[0..0], options)
+    end
+
     def handle_s_r_a_s_r_p_a(tokens, options)
       anchor_span = get_anchor(tokens[4..tokens.size - 1], options)
 

--- a/test/test_parsing.rb
+++ b/test/test_parsing.rb
@@ -997,6 +997,11 @@ class TestParsing < TestCase
     # future
   end
 
+  def test_parse_guess_rmn_s_r_p
+    time = parse_now("september 3 years ago", :guess => :start)
+    assert_equal Time.local(2003, 9), time
+  end
+
   def test_parse_guess_o_r_g_r
     time = parse_now("3rd month next year", :guess => false)
     assert_equal Time.local(2007, 3), time.begin


### PR DESCRIPTION
I really wanted to add support for a bunch more. Anything of the form S_R_P_A can be sanely written as A_S_R_P, such as "1st September 2 years ago"/"2 years ago 1st September". Enumerating all those seems a bit nuts though. Any ideas of the right approach to try and support all those patterns in a sane way?
