### PR TITLE
Do not delete :now from the options hash.

### DIFF
--- a/lib/chronic/parser.rb
+++ b/lib/chronic/parser.rb
@@ -56,7 +56,7 @@ module Chronic
     #                 future, `now - x years` is assumed to be the past.
     def initialize(options = {})
       @options = DEFAULT_OPTIONS.merge(options)
-      @now = options.delete(:now) || Chronic.time_class.now
+      @now = options[:now] || Chronic.time_class.now
     end
 
     # Parse "text" with the given options


### PR DESCRIPTION
Sometimes you want to share the options Hash between multiple calls to Chronic. The existed behavior produced very confusing bugs caused by a parameter disappearing from that shared config.

About the fix. Deleting `:now` option was needed, because the provided options hash would previously be frozen and assigned to a class variable. See [1130ba2f818238aad9df2e945b0eb0285717e3c8](https://github.com/mojombo/chronic/blob/1130ba2f818238aad9df2e945b0eb0285717e3c8/lib/chronic.rb#L211). Since it’s not the case anymore, I can see no sense in mutating the function arguments.
