### PR TITLE
Improve German date format parser

### DIFF
--- a/lib/chronic/parser.rb
+++ b/lib/chronic/parser.rb
@@ -94,7 +94,7 @@ module Chronic
     # Returns a new String ready for Chronic to parse.
     def pre_normalize(text)
       text = text.to_s.downcase
-      text.gsub!(/\b(\d{2})\.(\d{2})\.(\d{4})\b/, '\3 / \2 / \1')
+      text.gsub!(/\b(\d{1,2})\.(\d{1,2})\.(\d{4})\b/, '\3 / \2 / \1')
       text.gsub!(/\b([ap])\.m\.?/, '\1m')
       text.gsub!(/(\s+|:\d{2}|:\d{2}\.\d+)\-(\d{2}:?\d{2})\b/, '\1tzminus\2')
       text.gsub!(/\./, ':')

--- a/test/test_parsing.rb
+++ b/test/test_parsing.rb
@@ -345,6 +345,9 @@ class TestParsing < TestCase
     time = parse_now("09.08.2013")
     assert_equal Time.local(2013, 8, 9, 12), time
 
+    time = parse_now("9.8.2013")
+    assert_equal Time.local(2013, 8, 9, 12), time
+
     time = parse_now("30-07-2013 21:53:49")
     assert_equal Time.local(2013, 7, 30, 21, 53, 49), time
   end


### PR DESCRIPTION
This allow to parse German dates without leading zeros, e.g. 1.1.2015 instead of 01.01.2015
