### PR TITLE
Support "a" preposition - "in an hour" / "in a day"

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ Complex
 * 7 days from now
 * 1 week hence
 * in 3 hours
+* in an hour
+* in a day
 * 1 year ago tomorrow
 * 3 months ago saturday at 5:00 pm
 * 7 hours before tomorrow at noon

--- a/lib/chronic/parser.rb
+++ b/lib/chronic/parser.rb
@@ -117,6 +117,7 @@ module Chronic
       text.gsub!(/(\d{1,2}) (after|past)\b/, '\1 minutes future')
       text.gsub!(/\b(?:ago|before(?: now)?)\b/, 'past')
       text.gsub!(/\bthis (?:last|past)\b/, 'last')
+      text.gsub!(/\bin an?\b/, 'in 1')
       text.gsub!(/\b(?:in|during) the (morning)\b/, '\1')
       text.gsub!(/\b(?:in the|during the|at) (afternoon|evening|night)\b/, '\1')
       text.gsub!(/\btonight\b/, 'this night')

--- a/test/test_parsing.rb
+++ b/test/test_parsing.rb
@@ -1243,6 +1243,12 @@ class TestParsing < TestCase
     assert_equal pre_normalize("8:00 pm February 11"), pre_normalize("8:00 p.m. February 11")
   end
 
+  def test_normalizing_prepositions
+    assert_equal pre_normalize("in an hour"), pre_normalize("in 1 hour")
+    assert_equal pre_normalize("in a hour"), pre_normalize("in 1 hour")
+    assert_equal pre_normalize("in a day"), pre_normalize("in 1 day")
+  end
+
   private
   def parse_now(string, options={})
     Chronic.parse(string, {:now => TIME_2006_08_16_14_00_00 }.merge(options))


### PR DESCRIPTION
Fix for issue "mojombo/chronic#308"

Chronic would now support:

``` ruby
Chronic.parse("in an hour")
Chronic.parse("in a day")
```
