### PR TITLE
Use a map to avoid dynamic gsub

### DIFF
--- a/lib/chronic/handler.rb
+++ b/lib/chronic/handler.rb
@@ -86,7 +86,7 @@ module Chronic
     private
 
     def tags_match?(name, tokens, token_index)
-      klass = Chronic.const_get(name.to_s.gsub(/(?:^|_)(.)/) { $1.upcase })
+      klass = Chronic::Tag.find_by_snake_name(name)
 
       if tokens[token_index]
         !tokens[token_index].tags.select { |o| o.kind_of?(klass) }.empty?

--- a/lib/chronic/tag.rb
+++ b/lib/chronic/tag.rb
@@ -2,6 +2,19 @@ module Chronic
   # Tokens are tagged with subclassed instances of this class when
   # they match specific criteria.
   class Tag
+    SNAKE_TO_CAMEL_MAP = {}
+
+    def self.inherited(subclass)
+      subclass_string = subclass.name[(subclass.name.rindex('::')+2)..-1]
+      subclass_string.gsub!(/([A-Z\d]+)([A-Z][a-z])/, '\1_\2'.freeze)
+      subclass_string.gsub!(/([a-z\d])([A-Z])/, '\1_\2'.freeze)
+      subclass_string.downcase!
+      SNAKE_TO_CAMEL_MAP[subclass_string] = subclass
+    end
+
+    def self.find_by_snake_name(underscore_string)
+      SNAKE_TO_CAMEL_MAP[underscore_string]
+    end
 
     attr_accessor :type
 


### PR DESCRIPTION
Same idea as #340 except less intrusive to the developer

I borrowed from active support `#underscore` method for snake casing