### PR TITLE
Fix Chronic.parse year 00 returns nil

### DIFF
--- a/lib/chronic/date.rb
+++ b/lib/chronic/date.rb
@@ -46,9 +46,8 @@ module Chronic
 
     # Checks if given number could be year
     def self.could_be_year?(year, width = nil)
-      year >= 1 && year <= 9999 && (width.nil? || width == 2 || width == 4)
+      year >= 0 && year <= 9999 && (width.nil? || width == 2 || width == 4)
     end
-
     # Build a year from a 2 digit suffix.
     #
     # year - The two digit Integer year to build from.


### PR DESCRIPTION
Addressed Issue #358 where Chronic.parse returns nil on year 00 
e.g. Chronic.parse('09/01/00') returns nil

<img width="303" alt="screen shot 2017-06-28 at 1 09 32 pm" src="https://user-images.githubusercontent.com/13497174/27621401-1f0c3962-5c03-11e7-8f53-91dfdf8fadea.png">
