### PR TITLE
Fix for future current month

### DIFF
--- a/lib/chronic/repeaters/repeater_month_name.rb
+++ b/lib/chronic/repeaters/repeater_month_name.rb
@@ -29,7 +29,7 @@ module Chronic
         when :future
           if @now.month < index
             @current_month_begin = Chronic.construct(@now.year, index)
-          elsif @now.month > index
+          elsif @now.month >= index
             @current_month_begin = Chronic.construct(@now.year + 1, index)
           end
         when :none

--- a/test/test_repeater_month_name.rb
+++ b/test/test_repeater_month_name.rb
@@ -28,6 +28,14 @@ class TestRepeaterMonthName < TestCase
     assert_equal Time.local(2006, 12), next_december.begin
     assert_equal Time.local(2007, 1), next_december.end
 
+    now_month = Date::MONTHNAMES[@now.month].downcase.to_sym
+    now_months = Chronic::RepeaterMonthName.new(now_month)
+    now_months.start = @now
+
+    next_now_month = now_months.next(:future)
+    assert_equal Time.local(2007, 8), next_now_month.begin
+    assert_equal Time.local(2007, 9), next_now_month.end
+
     # past
 
     mays = Chronic::RepeaterMonthName.new(:may)


### PR DESCRIPTION
Doesn't look like this project is very maintained, but thought I'd leave this here for anyone else with the same issue. 

This fixes 'Next January' whilst currently in January will correctly return January of the following year.