### PR TITLE
guard against nil `span` when calculating offset

### DIFF
--- a/lib/chronic/repeaters/repeater_minute.rb
+++ b/lib/chronic/repeaters/repeater_minute.rb
@@ -44,6 +44,8 @@ module Chronic
     end
 
     def offset(span, amount, pointer)
+      return nil unless span
+
       direction = pointer == :future ? 1 : -1
       span + direction * amount * MINUTE_SECONDS
     end

--- a/test/test_parsing.rb
+++ b/test/test_parsing.rb
@@ -1070,6 +1070,9 @@ class TestParsing < TestCase
 
     time = parse_now("t")
     assert_nil time
+
+    time = parse_now("01 Jan 1953 to 31 Dec 1954")
+    assert_nil time
   end
 
   def test_parse_span


### PR DESCRIPTION
Given a date range of the format "%d %b %Y to %d %b %Y" such as "01 Jan 1988 to 31 Dec 1999" chronic will throw the error `NoMethodError (undefined method '+' for nil:NilClass)`. This happens because getting the anchor won't work for some weirder date formats and just returns nil, that in turn gets passed to the offset method. 

It looks like it could probably happen with other repeaters as well, but I was unable to craft a string of sufficient silliness to cause it to happen in other repeaters. 

Now, instead of throwing an error, Chronic.parse will just return nil, which is consistent with the documentation. 