### PR TITLE
Array of dates

### DIFF
--- a/lib/chronic.rb
+++ b/lib/chronic.rb
@@ -95,6 +95,14 @@ module Chronic
     Parser.new(options).parse(text)
   end
 
+  def self.parse_array(array)
+    @array_dates = []
+    
+    array.each { |item| @array_dates.push(Parser.new(item[:options]).parse(item[:text])) }
+
+    @array_dates
+  end
+
   # Construct a new time object determining possible month overflows
   # and leap years.
   #

--- a/lib/chronic.rb
+++ b/lib/chronic.rb
@@ -95,12 +95,8 @@ module Chronic
     Parser.new(options).parse(text)
   end
 
-  def self.parse_array(array)
-    @array_dates = []
-    
-    array.each { |item| @array_dates.push(Parser.new(item[:options]).parse(item[:text])) }
-
-    @array_dates
+  def self.parse_array(items)    
+    items.map { |item| parse(item[:text], item[:options]) }
   end
 
   # Construct a new time object determining possible month overflows

--- a/test/test_parsing.rb
+++ b/test/test_parsing.rb
@@ -47,6 +47,26 @@ class TestParsing < TestCase
     assert_equal Time.new(Time.now.year, Time.now.month, 28), time
   end
 
+  def test_handle_array_generic
+    times = Chronic.parse_array([
+      {
+        'options': {},
+        'text': '2012-08-02T13:00:00'
+      },
+      {
+        'options': {},
+        'text': '2012-08-02T13:00:00+01:00'
+      },
+      {
+        'options': {},
+        'text': 'tomorrow'
+      }
+    ])
+
+    assert_equal Time.local(2012, 8, 2, 13), times[0]
+    assert_equal Time.utc(2012, 8, 2, 12), times[1]
+  end
+
   def test_handle_rmn_sd
     time = parse_now("aug 3")
     assert_equal Time.local(2007, 8, 3, 12), time


### PR DESCRIPTION
The issue #379 said about return one array of dates, like input be:

```
[
     {
          'options': {},
          'text': '2012-08-02T13:00:00'
     },
     {
          'options': {},
          'text': '2012-08-02T13:00:00+01:00'
     },
]
```
And output: 
[2012-08-02 13:00:00 -0300, 2012-08-02 13:00:00 +0100, 2019-09-10 12:00:00 -0300]

So I added a new method, parse_array than receives a array in input and use the same method of "Chronic.parse" for parse the dates and return an array of dates :)