### PR TITLE
Remove deprecated option from gemspec

### DIFF
--- a/chronic.gemspec
+++ b/chronic.gemspec
@@ -4,7 +4,6 @@ require 'chronic/version'
 Gem::Specification.new do |s|
   s.name = 'chronic'
   s.version = Chronic::VERSION
-  s.rubyforge_project = 'chronic'
   s.summary     = 'Natural language date/time parsing.'
   s.description = 'Chronic is a natural language date/time parser written in pure Ruby.'
   s.authors  = ['Tom Preston-Werner', 'Lee Jarvis']


### PR DESCRIPTION
NOTE: Gem::Specification#rubyforge_project= is deprecated with no replacement. It will be removed on or after 2019-12-01.