### PR TITLE
Test: use recent Minitest style

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -5,7 +5,7 @@ end
 
 require 'minitest/autorun'
 
-class TestCase < MiniTest::Test
+class TestCase < Minitest::Test
   def self.test(name, &block)
     define_method("test_#{name.gsub(/\W/, '_')}", &block) if block
   end


### PR DESCRIPTION
Current style has long been to use Minitest instead of MiniTest at least for 3 years, and with minitest 5.19, MiniTest usage support is hidden unless explicitly setting ENV["MT_COMPAT"].

https://github.com/minitest/minitest/commit/a2c6c18570f6f0a1bf6af70fe3b6d9599a13fdd6

Switch to use Minitest style.